### PR TITLE
feat(chat_bot): add !echo and !reminder commands

### DIFF
--- a/domains/chat_bot/plugins/echo_reminder_plugin.py
+++ b/domains/chat_bot/plugins/echo_reminder_plugin.py
@@ -5,7 +5,7 @@ from core.base_plugin import BasePlugin
 
 class EchoReminderPlugin(BasePlugin):
     """
-    Skeleton for the !echo [time] [message] command.
+    Schedules a delayed message using !echo or !reminder [time] [message].
     """
 
     def __init__(self, scheduler, twitch, state, event_bus, logger):
@@ -21,7 +21,8 @@ class EchoReminderPlugin(BasePlugin):
         await self.bus.subscribe("chat.command.received", self._on_command)
 
     async def _on_command(self, data: dict):
-        if data.get("command") != "!echo":
+        command = data.get("command", "").lower()
+        if command not in ["!echo", "!reminder"]:
             return
 
         # Check permissions (Broadcaster, Mod, or VIP)

--- a/domains/chat_bot/plugins/echo_reminder_plugin.py
+++ b/domains/chat_bot/plugins/echo_reminder_plugin.py
@@ -1,3 +1,5 @@
+import re
+from typing import Optional
 from core.base_plugin import BasePlugin
 
 class EchoReminderPlugin(BasePlugin):
@@ -8,13 +10,41 @@ class EchoReminderPlugin(BasePlugin):
     def __init__(self, event_bus, logger):
         self.bus = event_bus
         self.logger = logger
+        self._duration_regex = re.compile(r"^(\d+)([smh])$")
 
     async def on_boot(self):
-        # register for the chat command
+        # Register for the chat command
         await self.bus.subscribe("chat.command.received", self._on_command)
 
     async def _on_command(self, data: dict):
         if data.get("command") != "!echo":
             return
         
-        self.logger.info(f"[Echo] Command received from @{data.get('display_name')}")
+        # Get the full arguments string and split it
+        args_str = data.get("args", "")
+        if not args_str:
+            return
+            
+        parts = args_str.split(maxsplit=1)
+        time_str = parts[0]
+        
+        # Parse duration
+        seconds = self._parse_duration(time_str)
+        if seconds is None:
+            self.logger.warning(f"[Echo] Invalid duration: {time_str}")
+            return
+            
+        self.logger.info(f"[Echo] Parsed duration: {seconds}s from @{data.get('display_name')}")
+
+    def _parse_duration(self, duration_str: str) -> Optional[int]:
+        match = self._duration_regex.match(duration_str.lower())
+        if not match:
+            return None
+        
+        value, unit = match.groups()
+        value = int(value)
+        
+        if unit == "s": return value
+        if unit == "m": return value * 60
+        if unit == "h": return value * 3600
+        return None

--- a/domains/chat_bot/plugins/echo_reminder_plugin.py
+++ b/domains/chat_bot/plugins/echo_reminder_plugin.py
@@ -1,0 +1,20 @@
+from core.base_plugin import BasePlugin
+
+class EchoReminderPlugin(BasePlugin):
+    """
+    Skeleton for the !echo [time] [message] command.
+    """
+
+    def __init__(self, event_bus, logger):
+        self.bus = event_bus
+        self.logger = logger
+
+    async def on_boot(self):
+        # register for the chat command
+        await self.bus.subscribe("chat.command.received", self._on_command)
+
+    async def _on_command(self, data: dict):
+        if data.get("command") != "!echo":
+            return
+        
+        self.logger.info(f"[Echo] Command received from @{data.get('display_name')}")

--- a/domains/chat_bot/plugins/echo_reminder_plugin.py
+++ b/domains/chat_bot/plugins/echo_reminder_plugin.py
@@ -8,9 +8,10 @@ class EchoReminderPlugin(BasePlugin):
     Skeleton for the !echo [time] [message] command.
     """
 
-    def __init__(self, scheduler, twitch, event_bus, logger):
+    def __init__(self, scheduler, twitch, state, event_bus, logger):
         self.scheduler = scheduler
         self.twitch = twitch
+        self.state = state
         self.bus = event_bus
         self.logger = logger
         self._duration_regex = re.compile(r"^(\d+)([smh])$")
@@ -34,6 +35,15 @@ class EchoReminderPlugin(BasePlugin):
         if not is_permitted:
             return
         
+        # Concurrency limit check
+        current_count = self.state.get("echo_count", 0, namespace="echo")
+        if current_count >= 3:
+            await self.twitch.send_message(
+                data["channel"],
+                f"@{data.get('display_name')} Falló la programación: Se alcanzó el límite máximo de 3 eco simultáneos. ❌"
+            )
+            return
+
         # Get the full arguments string and split it
         args_str = data.get("args", "")
         if not args_str:
@@ -47,12 +57,14 @@ class EchoReminderPlugin(BasePlugin):
             return
 
         # Parse duration
-        seconds = self._parse_duration(time_str)
+        seconds = self._target_seconds = self._parse_duration(time_str)
         if seconds is None:
             self.logger.warning(f"[Echo] Invalid duration: {time_str}")
             return
             
-        # Schedule the echo using the scheduler tool
+        # Increment counter and schedule
+        self.state.set("echo_count", current_count + 1, namespace="echo")
+        
         run_at = datetime.now() + timedelta(seconds=seconds)
         self.scheduler.add_one_shot(
             run_at=run_at,
@@ -68,10 +80,14 @@ class EchoReminderPlugin(BasePlugin):
             data["channel"],
             f"@{display_name} Mensaje programado para dentro de {time_str}. 😊"
         )
-        self.logger.info(f"[Echo] Scheduled for @{display_name} in {seconds}s")
+        self.logger.info(f"[Echo] Scheduled for @{display_name} in {seconds}s (Count: {current_count + 1})")
 
     async def _send_echo(self, channel: str, message: str):
         try:
+            # Decrement counter
+            count = self.state.get("echo_count", 0, namespace="echo")
+            self.state.set("echo_count", max(0, count - 1), namespace="echo")
+
             await self.twitch.send_message(channel, message)
         except Exception as e:
             self.logger.error(f"[Echo] Error sending message: {e}")

--- a/domains/chat_bot/plugins/echo_reminder_plugin.py
+++ b/domains/chat_bot/plugins/echo_reminder_plugin.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timedelta
 from typing import Optional
 from core.base_plugin import BasePlugin
 
@@ -7,7 +8,9 @@ class EchoReminderPlugin(BasePlugin):
     Skeleton for the !echo [time] [message] command.
     """
 
-    def __init__(self, event_bus, logger):
+    def __init__(self, scheduler, twitch, event_bus, logger):
+        self.scheduler = scheduler
+        self.twitch = twitch
         self.bus = event_bus
         self.logger = logger
         self._duration_regex = re.compile(r"^(\d+)([smh])$")
@@ -27,14 +30,40 @@ class EchoReminderPlugin(BasePlugin):
             
         parts = args_str.split(maxsplit=1)
         time_str = parts[0]
+        message = parts[1] if len(parts) > 1 else ""
         
+        if not message:
+            return
+
         # Parse duration
         seconds = self._parse_duration(time_str)
         if seconds is None:
             self.logger.warning(f"[Echo] Invalid duration: {time_str}")
             return
             
-        self.logger.info(f"[Echo] Parsed duration: {seconds}s from @{data.get('display_name')}")
+        # Schedule the echo using the scheduler tool
+        run_at = datetime.now() + timedelta(seconds=seconds)
+        self.scheduler.add_one_shot(
+            run_at=run_at,
+            callback=self._send_echo,
+            job_id=f"echo_{datetime.now().timestamp()}",
+            channel=data["channel"],
+            message=message
+        )
+        
+        # Confirmation in chat
+        display_name = data.get("display_name")
+        await self.twitch.send_message(
+            data["channel"],
+            f"@{display_name} Mensaje programado para dentro de {time_str}. 😊"
+        )
+        self.logger.info(f"[Echo] Scheduled for @{display_name} in {seconds}s")
+
+    async def _send_echo(self, channel: str, message: str):
+        try:
+            await self.twitch.send_message(channel, message)
+        except Exception as e:
+            self.logger.error(f"[Echo] Error sending message: {e}")
 
     def _parse_duration(self, duration_str: str) -> Optional[int]:
         match = self._duration_regex.match(duration_str.lower())

--- a/domains/chat_bot/plugins/echo_reminder_plugin.py
+++ b/domains/chat_bot/plugins/echo_reminder_plugin.py
@@ -22,6 +22,17 @@ class EchoReminderPlugin(BasePlugin):
     async def _on_command(self, data: dict):
         if data.get("command") != "!echo":
             return
+
+        # Check permissions (Broadcaster, Mod, or VIP)
+        badges = data.get("badges", {})
+        is_permitted = (
+            data.get("is_mod") or 
+            data.get("is_broadcaster") or 
+            "vip" in badges
+        )
+        
+        if not is_permitted:
+            return
         
         # Get the full arguments string and split it
         args_str = data.get("args", "")

--- a/tests/test_echo_reminder_plugin.py
+++ b/tests/test_echo_reminder_plugin.py
@@ -30,25 +30,33 @@ async def test_echo_parsing_and_scheduling(plugin, mock_tools):
     }
     
     await plugin._on_command(data)
-    
-    # Verify parsing and scheduling
     mock_tools["scheduler"].add_one_shot.assert_called_once()
     kwargs = mock_tools["scheduler"].add_one_shot.call_args.kwargs
     assert kwargs["message"] == "Test message"
     assert kwargs["channel"] == "test_channel"
-    
-    # Check run_at is 10s from now
     diff = (kwargs["run_at"] - datetime.now()).total_seconds()
     assert 9 <= diff <= 11
-    
-    # Verify confirmation
     mock_tools["twitch"].send_message.assert_called_with(
         "test_channel",
         "@TestUser Mensaje programado para dentro de 10s. 😊"
     )
 
 @pytest.mark.anyio
-async def test_echo_permissions_denied(plugin, mock_tools):
+async def test_echo_reminder_synonym_accepted(plugin, mock_tools):
+    mock_tools["state"].get.return_value = 0
+    data = {
+        "command": "!reminder",
+        "args": "10s Synonym test",
+        "channel": "ch",
+        "display_name": "User",
+        "is_mod": True,
+        "badges": {}
+    }
+    
+    await plugin._on_command(data)
+    mock_tools["scheduler"].add_one_shot.assert_called_once()
+    kwargs = mock_tools["scheduler"].add_one_shot.call_args.kwargs
+    assert kwargs["message"] == "Synonym test"
     # Regular viewer
     data = {
         "command": "!echo",

--- a/tests/test_echo_reminder_plugin.py
+++ b/tests/test_echo_reminder_plugin.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timedelta
+from domains.chat_bot.plugins.echo_reminder_plugin import EchoReminderPlugin
+
+@pytest.fixture
+def mock_tools():
+    return {
+        "scheduler": MagicMock(),
+        "twitch": AsyncMock(),
+        "state": MagicMock(),
+        "event_bus": AsyncMock(),
+        "logger": MagicMock()
+    }
+
+@pytest.fixture
+def plugin(mock_tools):
+    return EchoReminderPlugin(**mock_tools)
+
+@pytest.mark.anyio
+async def test_echo_parsing_and_scheduling(plugin, mock_tools):
+    mock_tools["state"].get.return_value = 0
+    data = {
+        "command": "!echo",
+        "args": "10s Test message",
+        "channel": "test_channel",
+        "display_name": "TestUser",
+        "is_mod": True,
+        "badges": {}
+    }
+    
+    await plugin._on_command(data)
+    
+    # Verify parsing and scheduling
+    mock_tools["scheduler"].add_one_shot.assert_called_once()
+    kwargs = mock_tools["scheduler"].add_one_shot.call_args.kwargs
+    assert kwargs["message"] == "Test message"
+    assert kwargs["channel"] == "test_channel"
+    
+    # Check run_at is 10s from now
+    diff = (kwargs["run_at"] - datetime.now()).total_seconds()
+    assert 9 <= diff <= 11
+    
+    # Verify confirmation
+    mock_tools["twitch"].send_message.assert_called_with(
+        "test_channel",
+        "@TestUser Mensaje programado para dentro de 10s. 😊"
+    )
+
+@pytest.mark.anyio
+async def test_echo_permissions_denied(plugin, mock_tools):
+    # Regular viewer
+    data = {
+        "command": "!echo",
+        "args": "10s Test",
+        "is_mod": False,
+        "is_broadcaster": False,
+        "badges": {}
+    }
+    
+    await plugin._on_command(data)
+    mock_tools["scheduler"].add_one_shot.assert_not_called()
+
+@pytest.mark.anyio
+async def test_echo_vip_accepted(plugin, mock_tools):
+    mock_tools["state"].get.return_value = 0
+    data = {
+        "command": "!echo",
+        "args": "10s Test",
+        "is_mod": False,
+        "is_broadcaster": False,
+        "badges": {"vip": "1"},
+        "channel": "ch",
+        "display_name": "VIPUser"
+    }
+    
+    await plugin._on_command(data)
+    mock_tools["scheduler"].add_one_shot.assert_called_once()
+
+@pytest.mark.anyio
+async def test_echo_limit_reached(plugin, mock_tools):
+    # Simulate 3 pending echoes
+    mock_tools["state"].get.return_value = 3
+    data = {
+        "command": "!echo",
+        "args": "10s Test",
+        "channel": "ch",
+        "display_name": "ModUser",
+        "is_mod": True,
+        "badges": {}
+    }
+    
+    await plugin._on_command(data)
+    
+    # Verify error message
+    mock_tools["twitch"].send_message.assert_called_with(
+        "ch",
+        "@ModUser Falló la programación: Se alcanzó el límite máximo de 3 eco simultáneos. ❌"
+    )
+    mock_tools["scheduler"].add_one_shot.assert_not_called()
+
+@pytest.mark.anyio
+async def test_echo_counter_lifecycle(plugin, mock_tools):
+    mock_tools["state"].get.return_value = 0
+    data = {"command": "!echo", "args": "10s T", "channel": "ch", "is_mod": True, "display_name": "U", "badges": {}}
+    await plugin._on_command(data)
+    
+    mock_tools["state"].set.assert_called_with("echo_count", 1, namespace="echo")
+    
+    mock_tools["state"].get.return_value = 1
+    await plugin._send_echo("ch", "T")
+    
+    mock_tools["state"].set.assert_any_call("echo_count", 0, namespace="echo")

--- a/tests/test_echo_reminder_plugin.py
+++ b/tests/test_echo_reminder_plugin.py
@@ -57,7 +57,9 @@ async def test_echo_reminder_synonym_accepted(plugin, mock_tools):
     mock_tools["scheduler"].add_one_shot.assert_called_once()
     kwargs = mock_tools["scheduler"].add_one_shot.call_args.kwargs
     assert kwargs["message"] == "Synonym test"
-    # Regular viewer
+
+@pytest.mark.anyio
+async def test_echo_permissions_denied(plugin, mock_tools):
     data = {
         "command": "!echo",
         "args": "10s Test",


### PR DESCRIPTION
This PR adds a plugin for scheduling one-shot chat reminders. It is brand-agnostic and follows the project's architecture rules.

Esta PR agrega un plugin para programar recordatorios de un solo uso en el chat. Es agnóstico a la marca y sigue las reglas de arquitectura del proyecto.

### Checklist:
- [x] `main.py` intacto (sin modificaciones).
- [x] Sin importaciones de otros dominios.
- [x] Single-file plugin en `domains/chat_bot/plugins/`.
- [x] Se incluye unit testing en `tests/test_echo_reminder_plugin.py`.

<details>
<summary><b>Leer detalles en Español</b> (Haz clic para expandir)</summary>
<br>

Agregué un nuevo plugin al dominio `chat_bot` para permitir que los moderadores y VIPs programen mensajes (reminders) en el chat (one-shot).

En total, la PR consta de dos archivos: 
- **`echo_reminder_plugin.py`**: El archivo del plugin que contiene la lógica de los comandos.
- **`test_echo_reminder_plugin.py`**: unit testing (obligatorio según los guidelines del repo).

### Cómo se usaría:
El comando acepta una duración seguida del mensaje. Soporta segundos (s), minutos (m) y horas (h).

**Ejemplos en el chat:**
- `!echo 30s ¡Hidrátate!` -> Envía el mensaje en 30 segundos.
- `!reminder 5m El sorteo empieza en breve` -> Envía el mensaje en 5 minutos.
- `!echo 1h No olvides estirar` -> Envía el mensaje en 1 hora.

### Cambios principales:
- **`echo_reminder_plugin.py`**: Detecta los comandos `!echo` y `!reminder`, convierte el tiempo (ejemplo: 10s, 5m, 1h) a segundos y usa el `scheduler` interno para enviar el mensaje después del retraso.
- **Seguridad**: Validado solo para el Broadcaster, los Moderadores y los usuarios con el emblema de VIP.
- **Control de spam**: Se configuró un límite máximo de 3 recordatorios activos al mismo tiempo para no saturar el chat.

### Cumplimiento de reglas del repo:
- Es un solo archivo que el kernel carga automáticamente.
- Se usó inyección de dependencias para las herramientas del core (`scheduler`, `twitch`, `state`, etc.).
- No se agregaron dependencias externas ni se tocaron otros dominios.

### Pruebas:
Incluí el unit testing en `tests/test_echo_reminder_plugin.py` para validar los permisos, los límites y el parseo de tiempo.

</details>

<details>
<summary><b>Read English Summary</b> (Click to expand)</summary>
<br>

I've added a new plugin to the `chat_bot` domain to allow moderators and VIPs to schedule one-shot messages (reminders) in the chat.

The PR consists of two files:
- **`echo_reminder_plugin.py`**: The plugin file containing the command logic.
- **`test_echo_reminder_plugin.py`**: Unit testing (mandatory according to the repo's guidelines).

### Usage:
The command accepts a duration followed by the message. It supports seconds (s), minutes (m), and hours (h).

**Chat examples:**
- `!echo 30s Drink water!` -> Sends the message in 30 seconds.
- `!reminder 5m Giveaway starting soon` -> Sends the message in 5 minutes.
- `!echo 1h Don't forget to stretch` -> Sends the message in 1 hour.

### Main changes:
- **Logic**: Detects the `!echo` and `!reminder` commands, converts the time to seconds, and uses the internal `scheduler`.
- **Security**: Restricted to Broadcasters, Moderators, and VIPs only.
- **Spam control**: A maximum limit of 3 active reminders at the same time to prevent chat saturation.

### Repository guidelines compliance:
- Single file automatically discovered by the kernel.
- Dependency Injection for core tools (`scheduler`, `twitch`, `state`, etc.).
- No external dependencies added and no other domains touched.

### Testing:
I included unit tests in `tests/test_echo_reminder_plugin.py` to validate permissions, limits, and time parsing. All tests passed successfully with `uv run pytest`.

</details>